### PR TITLE
Prefix demo URL with https

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,7 @@ description = "A modern simple Zola's theme related to docs as code methodology"
 license = "MIT"
 homepage = "https://github.com/codeandmedia/zola_docsascode_theme"
 min_version = "0.10.0"
-demo = "docsascode.codeandmedia.com"
+demo = "https://docsascode.codeandmedia.com"
 
 [author]
 name = "Roman Soldatenkov"


### PR DESCRIPTION
This is done to fix an issue with Zola documentation generation. Because the URL doesn't have `https://` prefixed, the demo URL is broken.

See https://github.com/getzola/zola/pull/1009#issuecomment-619602423