### PR TITLE
Remove flash when switching between pages in dark-mode

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,43 +1,38 @@
 @charset "utf-8";
 
 * {
-  padding:0;
-  margin: 0;
-  }
-  
-  ::selection {
-    background: blue;
-    color: #fafafa;
-  }
+padding:0;
+margin: 0;
+}
 
-  html {
-    font-kerning: normal;
-    text-rendering: optimizeLegibility;
-    scroll-behavior: smooth;
-    
-      &.theme-change-active{
-        animation: fade-in ease-out 0.6s;
-      }
-    }
+::selection {
+  background: blue;
+  color: #fafafa;
+}
 
-    $theme-light-first-text-color: #444;
-    $theme-dark-first-text-color: #888;
-    $theme-light-second-text-color: #999;
-    $theme-dark-second-text-color: #666;
-    $theme-light-bg-color:#fafafa;
-    $theme-dark-bg-color:#262626;
-  
-    @mixin color($property, $var, $fallback){
-      #{$property}: $fallback; 
-      #{$property}: var($var, $fallback);
-    }
-  
-    .theme-dark {
-      --first-text-color: #{$theme-dark-first-text-color};
-      --second-text-color:#{$theme-dark-second-text-color};
-      --bg-color: #{$theme-dark-bg-color};
-    }
+html {
+  font-kerning: normal;
+  text-rendering: optimizeLegibility;
+  scroll-behavior: smooth;
+}
 
+$theme-light-first-text-color: #444;
+$theme-dark-first-text-color: #888;
+$theme-light-second-text-color: #999;
+$theme-dark-second-text-color: #666;
+$theme-light-bg-color:#fafafa;
+$theme-dark-bg-color:#262626;
+
+@mixin color($property, $var, $fallback){
+  #{$property}: $fallback;
+  #{$property}: var($var, $fallback);
+}
+
+.theme-dark {
+  --first-text-color: #{$theme-dark-first-text-color};
+  --second-text-color:#{$theme-dark-second-text-color};
+  --bg-color: #{$theme-dark-bg-color};
+}
 
 body {
   text-rendering: optimizeLegibility;
@@ -51,21 +46,6 @@ body {
   @include color(color, --first-text-color, $theme-light-first-text-color);
 }
 
-@keyframes fade-in {
-  0% {
-    opacity: 0;
-  }
-  
-  50% {
-    opacity:0.8;
-  }
-  
-  100% {
-    opacity: 1;
-  }
-  }
-
- 
 .theme-button{
   display: none;
   padding:0;
@@ -105,7 +85,7 @@ a:visited {
   color:royalblue;
 }
 
-h1, h2, h3, h4, h5 {
+h1, h2, h3, h4, h5, h6 {
   .anchor {
     visibility: hidden;
     text-decoration: none;
@@ -189,7 +169,6 @@ main {
     margin:1rem 0 0;
 
     ul, ol {
-      list-style-position: inside;
       margin:0 0 1rem 1rem;
     }
   

--- a/static/initialize-theme.js
+++ b/static/initialize-theme.js
@@ -1,0 +1,35 @@
+
+  // Copyright Koos Looijesteijn https://www.kooslooijesteijn.net/blog/add-dark-mode-to-website 
+  // Find if user has set a preference and react to changes
+  (function initializeTheme(){
+    syncBetweenTabs()
+    listenToOSChanges()
+  }())
+  
+  // Listen to preference changes. The event only fires in inactive tabs, so theme changes aren't applied twice.
+  function syncBetweenTabs(){
+    window.addEventListener('storage', (e) => {
+      const root = document.documentElement
+      if (e.key === 'preference-theme'){
+        if (e.newValue === 'light') enableTheme('light', true, false)
+        else if (e.newValue === 'dark') enableTheme('dark', true, false) // The third argument makes sure the state isn't saved again.
+      }
+    })
+  }
+  
+  // Add a listener in case OS-level preference changes.
+  function listenToOSChanges(){
+    let mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)')
+  
+    mediaQueryList.addListener( (m)=> {
+      const root = document.documentElement
+      if (m.matches !== true){
+        if (!root.classList.contains('theme-light')){
+          enableTheme('light', true)
+        }
+      }
+      else{
+        if(!root.classList.contains('theme-dark')) enableTheme('dark', true)
+      }
+    })
+  }

--- a/static/update-theme-elements.js
+++ b/static/update-theme-elements.js
@@ -1,44 +1,12 @@
 
-  // Copyright Koos Looijesteijn https://www.kooslooijesteijn.net/blog/add-dark-mode-to-website 
-  // Find if user has set a preference and react to changes
-  (function initializeTheme(){
-    syncBetweenTabs()
-    listenToOSChanges()
+  (function updateThemeElements(){
     enableTheme(
       returnThemeBasedOnLocalStorage() ||
       returnThemeBasedOnOS() ||
       returnThemeBasedOnTime(),
       false)
   }())
-  
-  // Listen to preference changes. The event only fires in inactive tabs, so theme changes aren't applied twice.
-  function syncBetweenTabs(){
-    window.addEventListener('storage', (e) => {
-      const root = document.documentElement
-      if (e.key === 'preference-theme'){
-        if (e.newValue === 'light') enableTheme('light', true, false)
-        else if (e.newValue === 'dark') enableTheme('dark', true, false) // The third argument makes sure the state isn't saved again.
-      }
-    })
-  }
-  
-  // Add a listener in case OS-level preference changes.
-  function listenToOSChanges(){
-    let mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)')
-  
-    mediaQueryList.addListener( (m)=> {
-      const root = document.documentElement
-      if (m.matches !== true){
-        if (!root.classList.contains('theme-light')){
-          enableTheme('light', true)
-        }
-      }
-      else{
-        if(!root.classList.contains('theme-dark')) enableTheme('dark', true)
-      }
-    })
-  }
-  
+
   // If no preference was set, check what the OS pref is.
   function returnThemeBasedOnOS() {
     let mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)')
@@ -83,7 +51,7 @@
     let otherTheme
     newTheme === 'light' ? otherTheme = 'dark' : otherTheme = 'light'
     let currentTheme
-    (root.classList.contains('theme-dark')) ? currentTheme = 'dark' : 'light'
+    (root.classList.contains('theme-dark')) ? currentTheme = 'dark' : currentTheme = 'light'
   
     if (withTransition === true && newTheme !== currentTheme) animateThemeTransition()
   

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
       <title>{% block title %}{{ config.title }}{% endblock title %}</title>     
       <link rel="stylesheet" href="{{ get_url(path="main.css") | safe }}">
+      <script type="text/javascript" src="{{ get_url(path='initialize-theme.js') | safe }}"></script>
     </head>
 
     <body>
@@ -66,7 +67,7 @@
       {% endblock content %}
       </main>
 
-      <script type="text/javascript" src="{{ get_url(path="themes.js") | safe }}"></script>
+      <script type="text/javascript" src="{{ get_url(path='update-theme-elements.js') | safe }}"></script>
 
       <script>
         function burger() {

--- a/templates/search.html
+++ b/templates/search.html
@@ -16,10 +16,7 @@
         <ul class="search-results__items"></ul>
     </div>
 
-    <script src="{{ get_url(path="elasticlunr.min.js") | safe }}"></script>
-    <script src="{{ get_url(path="search_index.en.js") | safe }}"></script>
-    <script src="{{ get_url(path="search.js") | safe }}"></script>
+    <script defer src="{{ get_url(path='elasticlunr.min.js') | safe }}"></script>
+    <script defer src="{{ get_url(path='search_index.en.js') | safe }}"></script>
+    <script defer src="{{ get_url(path='search.js') | safe }}"></script>
 {% endblock content %}
-
-
-


### PR DESCRIPTION
## 📚 Description

Do not display the page in the white mode for 1 second when switching from page A to B when using `Dark Mode`,
and some other small improvements.

## 💡 Changes

- `sass/main.scss`
  - Reformat a little the file
  - Remove animation in `.theme-change-active` (switching from white to black is nice but it is not in the opposite way)
  - Remove `@keyframes fade-in` (not used anymore due to the previous item)
  - Add `h6` to `h#` list of elements
  - Remove in `ul, ol` style `list-style-position: inside;` in order to display the number and the element in the same line
- Splice `themes.js` class into two JS files
  - The first one (`static/initialize-theme.js`) loads the sync between tabs and listens to OS changes. It's loaded in `<head>` of `index.html`
  - The second one (`static/update-theme-elements.js`) adds classes to the items. It's loaded in the body of `index.html`, must be the DOM loaded first in order to be able to modify the DOM elements dynamically
- `search.html`: Define the JS scripts as `defer` as they took a little to be load 