### PR TITLE
feat(css): Widens content column

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -118,7 +118,7 @@ h1 {
 }
 
 nav {
-  width:34vw;
+  width:12vw;
   max-width:40rem;
   padding:4vw;
   display: flex;
@@ -154,9 +154,8 @@ nav {
 }
 
 main {
-  width:48vw;
+  width:72vw;
   padding:4vw;
-  max-width:55rem;
   display: flex;
   flex-flow: column nowrap;
   margin-top:2.375rem;


### PR DESCRIPTION
I’m proposing this pull request to widen the content column. Currently, the navbar is as wide as the actual content, and I feel like it doesn’t make sense. Of course, the values I propose are arbitrary, and you may want to change them.